### PR TITLE
sender is now mfrom; gsub out injection attacks

### DIFF
--- a/lib/spfquery.rb
+++ b/lib/spfquery.rb
@@ -9,9 +9,13 @@ class Spfquery
   end
 
   def initialize(ip, sender, helo=nil)
-    @ip = ip
-    @sender = sender
+    @ip = clean(ip)
+    @sender = clean(sender)
     @helo = helo
+  end
+
+  def clean(str)
+    str.gsub(/;.*/, '')
   end
 
   def pass?
@@ -35,7 +39,7 @@ class Spfquery
   end
 
   def run_spfquery
-    args = ['spfquery', "--ip=#{ip}", "--sender=#{sender}"]
+    args = ['spfquery', "--ip=#{ip}", "--mfrom=#{sender}"]
     args << "--helo=#{helo}"  if helo
     Open3.popen3(*args) do |stdin, stdout, stderr, wait_thr|
       stdout.read

--- a/ruby-spfquery.gemspec
+++ b/ruby-spfquery.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep(%r{^test/})
   gem.require_paths = ['lib']
+  gem.add_development_dependency 'minitest'
 end


### PR DESCRIPTION
@brettg Can you take a look? Some minor changes. 

Also, minitest wasn't added a development dependency.

This was causing false-negatives as the deprecation warning was the first line out, not the pass/fail.
